### PR TITLE
media-sound/ardour-6.0_pre20190416: need fluidsynth-2.0.1 with USE=-bundled-libs

### DIFF
--- a/media-sound/ardour/ardour-6.9999.ebuild
+++ b/media-sound/ardour/ardour-6.9999.ebuild
@@ -50,6 +50,7 @@ RDEPEND="
 		media-libs/libltc
 		media-libs/qm-dsp
 		hid? ( dev-libs/hidapi )
+		>=media-sound/fluidsynth-2.0.1
 	)
 	media-libs/liblo
 	media-libs/taglib


### PR DESCRIPTION
Closes issue #38 