### PR TITLE
media-fonts/iosevka: support experimental variants

### DIFF
--- a/media-fonts/iosevka/iosevka-9999.ebuild
+++ b/media-fonts/iosevka/iosevka-9999.ebuild
@@ -21,10 +21,14 @@ MY_FONT_VARIANTS=(
 	ss09
 	ss10
 	ss11
+	etoile
+	aile
+	extended
 )
 if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/be5invis/${PN}.git"
+	EGIT_BRANCH="dev"
 	REQUIRED_USE="!binary"
 else
 	SRC_URI="https://github.com/be5invis/${PN^}/releases/download/v${PV}/"
@@ -157,6 +161,10 @@ src_compile() {
 		fi
 		for _s in $(seq -w 11); do
 			use font_variants_ss${_s} && _t+=( ${PN}-ss${_s} )
+		done
+
+		for _s in etoile aile extended; do
+			use font_variants_${_s} && _t+=( ${PN}-${_s} )
 		done
 
 		emake ${_t[@]/#/${_v}::}


### PR DESCRIPTION
Iosevka supports three new experimental variants -- add them to the ebuild and make the `9999` ebuild use the `dev` branch instead of `master`, which contains newer changes related to these fonts.
The versioned ebuilds still use `master` and also support these fonts.

Signed-off-by: Shane Peelar <lookatyouhacker@gmail.com>