### PR TITLE
modify: fix megasync-4.6.0.0 ebuild.

### DIFF
--- a/dev-libs/breakpad/breakpad-0_p20210407-r1.ebuild
+++ b/dev-libs/breakpad/breakpad-0_p20210407-r1.ebuild
@@ -1,0 +1,65 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+# DEPS: src/third_party/lss
+MY_LSS="linux-syscall-support-fd00dbb"
+if [[ ${PV} = *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/google/${PN}.git"
+else
+	MY_PV="c484031"
+	SRC_URI="
+		mirror://githubcl/google/${PN}/tar.gz/${MY_PV} -> ${P}.tar.gz
+		mirror://githubcl/stefanJi/${MY_LSS%-*}/tar.gz/${MY_LSS##*-}
+		-> ${MY_LSS}.tar.gz
+	"
+	RESTRICT="primaryuri"
+	KEYWORDS="~amd64 ~x86"
+	S="${WORKDIR}/${PN}-${MY_PV}"
+fi
+inherit autotools
+
+DESCRIPTION="A crash-reporting system"
+HOMEPAGE="https://chromium.googlesource.com/${PN}/${PN}"
+
+LICENSE="BSD"
+SLOT="0"
+
+IUSE="processor tools"
+
+RDEPEND="
+"
+DEPEND="
+	${RDEPEND}
+"
+PATCHES=(
+        "${FILESDIR}"/${PN}-fix-glibc-types.patch
+)
+
+src_unpack() {
+	if [[ -z ${PV%%*9999} ]]; then
+		git-r3_src_unpack
+		EGIT_REPO_URI="https://chromium.googlesource.com/${MY_LSS%-*}" \
+		EGIT_CHECKOUT_DIR="${WORKDIR}/${MY_LSS}" \
+			git-r3_src_unpack
+	else
+		default
+	fi
+}
+
+src_prepare() {
+	ln -s ../../../${MY_LSS} src/third_party/lss
+	sed -e '/docdir = /d' -i Makefile.am
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable processor)
+		$(use_enable tools)
+	)
+	econf "${myeconfargs[@]}"
+}

--- a/dev-libs/breakpad/files/breakpad-fix-glibc-types.patch
+++ b/dev-libs/breakpad/files/breakpad-fix-glibc-types.patch
@@ -1,0 +1,11 @@
+--- a/src/client/linux/handler/exception_handler.cc	2021-11-23 21:30:12.099604418 +0800
++++ b/src/client/linux/handler/exception_handler.cc	2021-11-23 21:30:53.589602997 +0800
+@@ -138,7 +138,7 @@
+   // SIGSTKSZ may be too small to prevent the signal handlers from overrunning
+   // the alternative stack. Ensure that the size of the alternative stack is
+   // large enough.
+-  static const unsigned kSigStackSize = std::max(16384, SIGSTKSZ);
++  static const unsigned kSigStackSize = std::max<long>(16384, SIGSTKSZ);
+ 
+   // Only set an alternative stack if there isn't already one, or if the current
+   // one is too small.

--- a/net-misc/megasync/megasync-4.6.0.0-r1.ebuild
+++ b/net-misc/megasync/megasync-4.6.0.0-r1.ebuild
@@ -1,0 +1,98 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MY_PN="MEGAsync"
+if [[ -z ${PV%%*9999} ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/meganz/${MY_PN}.git"
+	EGIT_SUBMODULES=( -src/MEGASync/mega )
+	SRC_URI=
+else
+	MY_PV="563aa08"
+	SRC_URI="
+		mirror://githubcl/meganz/${MY_PN}/tar.gz/${MY_PV}
+		-> ${P}.tar.gz
+	"
+	RESTRICT="primaryuri"
+	KEYWORDS="~amd64 ~x86"
+	S="${WORKDIR}/${MY_PN}-${MY_PV}"
+fi
+CMAKE_USE_DIR="${S}/src/MEGAShellExtDolphin"
+CMAKE_IN_SOURCE_BUILD=y
+inherit cmake qmake-utils xdg
+
+DESCRIPTION="Easy automated syncing with MEGA Cloud Drive"
+HOMEPAGE="https://github.com/meganz/MEGAsync"
+
+LICENSE="EULA"
+LICENSE_URL="https://raw.githubusercontent.com/meganz/MEGAsync/master/LICENCE.md"
+SLOT="0"
+IUSE="dolphin nautilus thunar"
+
+RDEPEND="
+	>=net-misc/meganz-sdk-3.8.2c:=[libuv,qt,sodium(+),sqlite]
+	dev-qt/qtsvg:5
+	dev-qt/qtx11extras:5
+	dev-qt/qtdbus:5
+	dev-qt/qtconcurrent:5
+	dev-qt/qtimageformats:5
+	media-libs/freeimage
+	dolphin? ( kde-apps/dolphin )
+	nautilus? ( >=gnome-base/nautilus-3 )
+	thunar? ( xfce-base/thunar )
+"
+DEPEND="
+	${RDEPEND}
+	dev-libs/breakpad
+"
+BDEPEND="
+	dev-qt/linguist-tools:5
+"
+src_prepare() {
+	local PATCHES=(
+		"${FILESDIR}"/${PN}-qmake.diff
+	)
+	sed \
+		-e "/include(/ s:mega/bindings/qt/:${EROOT}/usr/share/&:" \
+		-i src/MEGASync/MEGASync.pro
+	cmake_src_prepare
+	mv -f src/MEGAShellExtDolphin/CMakeLists{_kde5,}.txt
+	rm -f src/MEGAShellExtDolphin/megasync-plugin.moc
+	printf 'CONFIG += link_pkgconfig
+		PKGCONFIG += breakpad-client
+		DEFINES += __STDC_FORMAT_MACROS\n' > \
+		src/MEGASync/google_breakpad/google_breakpad.pri
+	sed \
+		-e "/USE_\(FFMPEG\|LIBRAW\|MEDIAINFO\)/s:+:-:" \
+		-i src/MEGASync/MEGASync.pro
+}
+
+src_configure() {
+	cd src
+	local eqmakeargs=(
+		CONFIG$(usex nautilus + -)=with_ext
+		CONFIG$(usex thunar + -)=with_thu
+		CONFIG-=with_updater
+		CONFIG-=with_tools
+		MEGASDK_BASE_PATH="${EROOT}/usr"
+	)
+	eqmake5 "${eqmakeargs[@]}"
+	use dolphin && cmake_src_configure
+}
+
+src_compile() {
+	cd src
+	$(qt5_get_bindir)/lrelease \
+		MEGASync/MEGASync.pro
+	emake
+	use dolphin && cmake_src_compile
+}
+
+src_install() {
+	local DOCS=( CREDITS.md README.md )
+	einstalldocs
+	emake -C src INSTALL_ROOT="${D}" install
+	use dolphin && cmake_src_install
+}


### PR DESCRIPTION
1. breakpad need a patch to fix glibc type issue.
2. megasync need freeimage to build.